### PR TITLE
Fix matrix multiplication

### DIFF
--- a/matrices.c
+++ b/matrices.c
@@ -264,7 +264,7 @@ Matrix *multiply(Matrix *m1, Matrix *m2){
 	product = constructor(m1->rows, m2->columns);
 	for(i = 0; i < product->columns; i++){
 		for(j = 0; j < product->rows; j++){
-			product->numbers[i][j] = vector_multiply(trans->numbers[j], m2->numbers[i], product->rows);
+			product->numbers[i][j] = vector_multiply(trans->numbers[j], m2->numbers[i], m2->rows);
 		}
 	}
 	destroy_matrix(trans);


### PR DESCRIPTION
I've been working with your library while playing around with Ruby (https://github.com/Bajena/matrix_boost) and noticed a bug in `multiply` function.

This test confirms that the change is correct: https://github.com/Bajena/matrix_boost/blob/master/test/matrix_boost_test.rb

without this change it fails like this:
![image](https://user-images.githubusercontent.com/5732023/79055403-07002f00-7c4d-11ea-90b4-3f640739ba70.png)
